### PR TITLE
Fixed touch bug

### DIFF
--- a/unisens-library/src/org/unisens/ri/EntryImpl.java
+++ b/unisens-library/src/org/unisens/ri/EntryImpl.java
@@ -24,7 +24,6 @@ along with the Unisens Library. If not, see <http://www.gnu.org/licenses/>.
 package org.unisens.ri;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -71,13 +70,15 @@ public abstract class EntryImpl implements Entry , Constants{
 		this.unisens = unisens;
 		this.id = id;
 		String absoluteFileName = unisens.getPath() + id;
-	    try
-	    {
-	    	new FileOutputStream(absoluteFileName).close();
-	    }
-        catch (IOException e)
-        {
-        }	    	
+	    	try {
+	    		File file = new File(absoluteFileName);
+			if (!file.exists())
+			{
+				file.createNewFile();
+			}
+	   	}
+        	catch (IOException e) {
+        	}	    	
 	}
 	
 	protected EntryImpl(Entry entry){


### PR DESCRIPTION
Existing files will not touched or deleted when creating a new entry. If no file exists, the library will create an empty file.